### PR TITLE
ci(travis): use default matrix after `centos-6` image fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,11 @@ jobs:
     # - env: INSTANCE=default-debian-10-2019-2-py3
     # - env: INSTANCE=default-debian-9-2019-2-py3
     - env: INSTANCE=default-ubuntu-1804-2019-2-py3
-    - env: INSTANCE=default-centos-8-2019-2-py3
+    # - env: INSTANCE=default-centos-8-2019-2-py3
     # - env: INSTANCE=default-fedora-31-2019-2-py3
     - env: INSTANCE=default-opensuse-leap-151-2019-2-py3
     # - env: INSTANCE=default-centos-7-2019-2-py2
-    # - env: INSTANCE=default-amazonlinux-2-2019-2-py2
+    - env: INSTANCE=default-amazonlinux-2-2019-2-py2
     # - env: INSTANCE=default-arch-base-latest-2019-2-py2
     - env: INSTANCE=default-fedora-30-2018-3-py3
     # - env: INSTANCE=default-debian-9-2018-3-py2
@@ -79,10 +79,10 @@ jobs:
     - env: INSTANCE=default-arch-base-latest-2018-3-py2
     # - env: INSTANCE=default-debian-8-2017-7-py2
     # - env: INSTANCE=default-ubuntu-1604-2017-7-py2
-    # - env: INSTANCE=default-centos-6-2017-7-py2
+    - env: INSTANCE=default-centos-6-2017-7-py2
     # - env: INSTANCE=default-fedora-30-2017-7-py2
     # - env: INSTANCE=default-opensuse-leap-151-2017-7-py2
-    - env: INSTANCE=default-amazonlinux-2-2017-7-py2
+    # - env: INSTANCE=default-amazonlinux-2-2017-7-py2
     # - env: INSTANCE=default-arch-base-latest-2017-7-py2
 
     ## Define the release stage that runs `semantic-release`


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/105
* https://github.com/netmanagers/salt-image-builder/issues/18